### PR TITLE
Pin sagemaker version to 2.250.0 in requirements.txt

### DIFF
--- a/aiops-seed-code/regression/model_build/ml_pipelines/requirements.txt
+++ b/aiops-seed-code/regression/model_build/ml_pipelines/requirements.txt
@@ -1,3 +1,3 @@
 awscli
 boto3
-sagemaker
+sagemaker==2.250.0


### PR DESCRIPTION
without specific version sagemaker defaults to 3.X and the pipeline scripts will not work due to multiple breaking changes in 3.X

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
