### PR TITLE
Pin sagemaker<3 and add pytz in regression build requirements

### DIFF
--- a/aiops-seed-code/regression/model_build/ml_pipelines/requirements.txt
+++ b/aiops-seed-code/regression/model_build/ml_pipelines/requirements.txt
@@ -1,3 +1,4 @@
 awscli
 boto3
-sagemaker
+sagemaker<3
+pytz


### PR DESCRIPTION
## Problem
The `regression` build pipeline fails at the **Run Sagemaker Pipeline** step. `aiops-seed-code/regression/model_build/ml_pipelines/requirements.txt` leaves `sagemaker` unpinned, so CI installs the **SageMaker Python SDK v3**. v3 reorganized the package and `sagemaker.session` no longer imports the same way, so `run_pipeline.py` fails:

```
import sagemaker.session
ModuleNotFoundError: No module named 'sagemaker.session'
```

After pinning to v2, a second missing dependency surfaces: sagemaker 2.x's `sagemaker/workflow/pipeline.py` imports `pytz`, which isn't present in the runner environment:

```
from sagemaker.workflow.pipeline import Pipeline
ModuleNotFoundError: No module named 'pytz'
```

## Fix
Pin `sagemaker<3` and add `pytz` to the regression build requirements.

## Testing
With this change the regression build pipeline runs end to end: Preprocess → Train → Evaluate → MSE gate → RegisterModel, and the model registers successfully.
