### PR TITLE
Build Lambda dependency layer for the Python 3.9 runtime

### DIFF
--- a/smus-cdk/layers/python-layer/requirements.txt
+++ b/smus-cdk/layers/python-layer/requirements.txt
@@ -1,2 +1,3 @@
-boto3>=1.38.0
+boto3
 requests>=2.30.0
+urllib3<2  # urllib3 2.x is incompatible with the Python 3.9 Lambda runtime

--- a/smus-cdk/ml_ops_smus/constructs/dependency_layer.py
+++ b/smus-cdk/ml_ops_smus/constructs/dependency_layer.py
@@ -33,7 +33,15 @@ class DependencyLayerConstruct(Construct):
         try:
             print(f"Installing dependencies to {python_path}")
             subprocess.run(
-                ["pip", "install", "-r", requirements_path, "-t", python_path],
+                [
+                    "pip", "install",
+                    "--platform", "manylinux2014_x86_64",
+                    "--implementation", "cp",
+                    "--python-version", "3.9",
+                    "--only-binary=:all:",
+                    "-r", requirements_path,
+                    "-t", python_path,
+                ],
                 check=True,
                 capture_output=True,
                 text=True


### PR DESCRIPTION
## Problem
During project creation, the `ml-ops-project-setup` Step Functions execution fails because the project-setup Lambdas (e.g. `ai-ops-check-project-status`) crash on cold start with an import error:

```
TypeError: unsupported operand type(s) for |: 'type' and 'type'
  .../python3.9/.../urllib3/_base_connection.py
    typing.Iterable[bytes | str]
```

Root cause: `DependencyLayerConstruct` builds the layer with `pip install -r requirements.txt -t python/` using the **host** interpreter, so it resolves the latest packages. The Lambdas run on the **Python 3.9** runtime, but recent `urllib3` (2.x) and `botocore` use 3.10+ syntax (PEP 604 `X | Y`) and fail at import on 3.9.

## Fix
- Build the dependency layer with wheels targeted at the Lambda runtime: `--platform manylinux2014_x86_64 --implementation cp --python-version 3.9 --only-binary=:all:`, so pip resolves 3.9-compatible versions regardless of the host interpreter.
- In `layers/python-layer/requirements.txt`: unpin `boto3` (so a 3.9-compatible version resolves) and pin `urllib3<2`.

## Testing
After this change the project-setup Step Functions execution completes, the Lambdas import cleanly, and the build/deploy repositories are created in the configured GitHub org.
